### PR TITLE
Linkedin took away their countserv API 😟

### DIFF
--- a/src/jquery.floating-social-share.js
+++ b/src/jquery.floating-social-share.js
@@ -235,11 +235,6 @@
           appendButtons(issetOrZero(function () { return data.share.share_count; }), $component);
         });
         break;
-      case "linkedin":
-        $.getJSON("https://www.linkedin.com/countserv/count/share?url=" + url + "&callback=?", function(data) {
-          appendButtons(issetOrZero(function () { return data.count; }), $component);
-        });
-        break;
       case "odnoklassniki":
         $.getJSON("https://connect.ok.ru/dk?st.cmd=extLike&ref=" + url + "&callback=?", function() {});
         window.ODKL = window.ODKL || {};


### PR DESCRIPTION
Removing the reference to avoid a 404 showing up in the console every time the snippet loads.


### Reference
https://developer.linkedin.com/blog/posts/2018/deprecating-the-inshare-counter